### PR TITLE
Fix Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,28 @@
-You can hyperlink DOI numbers to dx.doi.org. Some publishers have elected to
-use some nasty characters in their doi numbering scheme (<, >, ; have all
-been spotted). This will either upset (La)TeX, or your pdf reader. This style
-file contains a user-level command \doi{}, which takes a doi number,
-and creates a hyperlink from it. The format of the doi can be controlled by
-redefining the \doitext command, which does not take an argument (unlike the
-command with the same name in the doipubmed package).
+# doi.sty
 
-Note: the \doi{} command connot be used within other macros.
+You can hyperlink DOI numbers to <https://doi.org>. Some publishers have elected to
+use some nasty characters in their doi numbering scheme (`<`, `>`, `;` have all
+been spotted). This will either upset (La)TeX, or your pdf reader. This style
+file contains a user-level command `\doi{}`, which takes a doi number,
+and creates a hyperlink from it. The format of the doi can be controlled by
+redefining the `\doitext` command, which does not take an argument (unlike the
+command with the same name in the [doipubmed package](https://www.ctan.org/pkg/doipubmed)).
+
+Note: the `\doi{}` command connot be used within other macros.
 
 This style file is based original code written by Heiko Oberdiek
-and published on comp.text.tex. It was packaged with permission
+and published on [comp.text.tex](https://groups.google.com/forum/#!forum/comp.text.tex). It was packaged with permission
 as a style file by Maarten Sneep, with some minor changes suggested
 by Bruno Voisin to accomodate the Apple pdf framework
 Michael Orlov noticed that underscores were not handled appropriately
 and sends in a patch.
-Now supported by the "Oberdiek Package Support Group" at GitHub.
+Now supported by the "[Oberdiek Package Support Group](https://github.com/ho-tex)" at GitHub.
 
 This code is placed under the LPPL.
 
 Original discussion on Google under:
-http://groups.google.com/group/comp.text.tex/msg/922919daa207d613
+<https://groups.google.com/group/comp.text.tex/msg/922919daa207d613>
 
 Comments and bug reports to
-https://github.com/ho-tex/doi/issues
+<https://github.com/ho-tex/doi/issues>
 


### PR DESCRIPTION
This PR adds Markdown to README.md

Additionally:

* links are added where appropriate
* changed dx.doi.org to doi.org - dx.doi.org is outdated - see also https://github.com/ho-tex/doi/blob/28dbd16ca59a89fb0cbe49754803338e32d55dc0/doi.sty#L54