### PR TITLE
Use doi.org (instead of dx.doi.org) also in the comment

### DIFF
--- a/doi.sty
+++ b/doi.sty
@@ -14,7 +14,7 @@
 %% Comments and bug reports may be submitted via
 %% https://github.com/ho-tex/doi/issues
 %%
-%% You can hyperlink DOI numbers to dx.doi.org. Some publishers have elected to 
+%% You can hyperlink DOI numbers to doi.org. Some publishers have elected to 
 %% use some nasty characters in their doi numbering scheme (<, >, ; have all 
 %% been spotted). This will either upset (La)TeX, or your pdf reader. This style 
 %% file contains a user-level command \doi{}, which takes a doi number, 


### PR DESCRIPTION
This makes the comment consistent to https://github.com/ho-tex/doi/blob/28dbd16ca59a89fb0cbe49754803338e32d55dc0/doi.sty#L54