### PR TITLE
Optional loading of hyperref

### DIFF
--- a/doi.sty
+++ b/doi.sty
@@ -39,10 +39,21 @@
 %%     https://doi.org/ URL but may be set to old http://dx.doi.org/
 %%
 
+%% Declare two complementary boolean options [no]hyperref that determine
+%% if hyperref should be loaded in this package.
+\newif\if@doihyperref\@doihyperreftrue
+\DeclareOption{hyperref}{\@doihyperreftrue}
+\DeclareOption{nohyperref}{\@doihyperreffalse}
+
+%% Execute default options and process the options passed to the package.
+\ExecuteOptions{hyperref} % default is the old behaviour, to load hyperref
+\ProcessOptions\relax
 
 %% We need hyperref, but you probably want to load hyperref 
 %% beforehand, or set some options later on.
-\RequirePackage{hyperref}
+\if@doihyperref
+  \RequirePackage{hyperref}
+\fi
 
 %% To change the default prefix, redefine this command within your own code.
 %% It takes no argument, which is different from the doipubmed package.

--- a/doi.sty
+++ b/doi.sty
@@ -99,7 +99,7 @@
   \edef\_{_}%
   \edef\textless{\@percentchar3C}% instead of {\string<} for Apple
   \edef\textgreater{\@percentchar3E}% instead of {\sting>} for Apple
-  \edef\x{\toks2={\noexpand\href{\doiurl#1}}}% 
+  \edef\x{\toks2={\ifdefined\href\noexpand\href{\doiurl#1}\fi}}% 
   \x
   \edef\x{\endgroup\doitext\the\toks2 \the\toks0}%
   \x


### PR DESCRIPTION
This package relies on `hyperref` for the `href` command. However, loading it directly with `\RequirePackage{hyperref}` can cause problems for authors who place `\usepackage{doi}` early in their preamble and thus violate the rule that [hyperref should be loaded last](https://ctan.org/pkg/hyperref). One workaround is to [load doi after hyperref](https://tex.stackexchange.com/questions/1863/which-packages-should-be-loaded-after-hyperref-instead-of-before), but this is not documented in the `doi` package.

This PR adds the package options `hyperref` and `nohyperref`. The former matches the default (legacy) behaviour to call `\RequirePackage{hyperref}` while the latter omits this and leaves it up to the user to include the `hyperref` package separately.
